### PR TITLE
feat: make example audio configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # voicetotext
+
+A minimal example project for experimenting with audio transcription.
+
+## Running the example
+
+The repository no longer includes an embedded audio file. Supply your own
+WAV file or allow the example script to fetch a small sample clip at
+runtime:
+
+```bash
+python examples/transcribe_example.py --audio path/to/your/audio.wav
+```
+
+Omit the `--audio` flag to download a short sample clip
+automatically. The resulting transcript will be written to
+`transcript.txt` by default or to the path given by `--output`.
+
+The pipeline requires [ffmpeg](https://ffmpeg.org/) to split the audio
+into chunks. Make sure it is installed and available on your `PATH`.

--- a/examples/transcribe_example.py
+++ b/examples/transcribe_example.py
@@ -1,0 +1,68 @@
+"""Simple demonstration of the transcription pipeline.
+
+This script accepts a path to an audio file on the command line. If no
+path is provided a small sample file will be downloaded at runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# Ensure project ``src`` directory is on the module search path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from cli import run_pipeline  # pylint: disable=import-error
+
+
+def download_sample() -> Path:
+    """Download a short sample audio file and return its path."""
+    url = "https://raw.githubusercontent.com/ggerganov/whisper.cpp/master/samples/jfk.wav"
+
+    tmp_dir = Path(tempfile.mkdtemp())
+    sample_path = tmp_dir / "sample.wav"
+    urllib.request.urlretrieve(url, sample_path)  # noqa: S310
+    return sample_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Transcribe an audio file")
+    parser.add_argument(
+        "--audio",
+        help="Path to a WAV audio file. If omitted, a sample will be downloaded.",
+    )
+    parser.add_argument(
+        "--output",
+        default="transcript.txt",
+        help="Path for the generated transcript (default: transcript.txt)",
+    )
+    args = parser.parse_args()
+
+    if args.audio:
+        audio_path = Path(args.audio)
+        if not audio_path.exists():
+            parser.error(f"Audio file not found: {audio_path}")
+    else:
+        audio_path = download_sample()
+        print(f"Downloaded sample audio to {audio_path}")
+
+    run_pipeline(audio_path, args.output)
+    print(f"Transcript written to {args.output}")
+
+    if not args.audio:
+        # Clean up downloaded sample
+        try:
+            audio_path.unlink()
+            audio_path.parent.rmdir()
+        except OSError:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add example script that accepts audio path or downloads sample clip
- document how to supply or fetch audio files for examples

## Testing
- `pytest -q`
- `python examples/transcribe_example.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68b6dd49ee3883208f71d7c7cf87dfdb