### PR TITLE
Enhance logging in transcribe example

### DIFF
--- a/examples/transcribe_example.py
+++ b/examples/transcribe_example.py
@@ -7,6 +7,7 @@ path is provided a small sample file will be downloaded at runtime.
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 import tempfile
 import urllib.request
@@ -40,6 +41,9 @@ def main() -> int:
         default="transcript.txt",
         help="Path for the generated transcript (default: transcript.txt)",
     )
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    logger = logging.getLogger(__name__)
+
     args = parser.parse_args()
 
     if args.audio:
@@ -48,10 +52,11 @@ def main() -> int:
             parser.error(f"Audio file not found: {audio_path}")
     else:
         audio_path = download_sample()
-        print(f"Downloaded sample audio to {audio_path}")
+        logger.info("Downloaded sample audio to %s", audio_path)
 
+    logger.info("Starting transcription pipeline")
     run_pipeline(audio_path, args.output)
-    print(f"Transcript written to {args.output}")
+    logger.info("Transcript written to %s", args.output)
 
     if not args.audio:
         # Clean up downloaded sample


### PR DESCRIPTION
## Summary
- Configure logging so `cli.run_pipeline` emits informational messages
- Replace prints with `logging.info` and log when the example runs the pipeline

## Testing
- `python -m py_compile examples/transcribe_example.py`
- `python examples/transcribe_example.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f149e52083208069096b5f59a8b9