### PR TITLE
Add GPU transcription option and example script

### DIFF
--- a/examples/transcribe_gpu.py
+++ b/examples/transcribe_gpu.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""Transcribe an audio file using the GPU-enabled pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Ensure project ``src`` directory is on the module search path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from cli import run_pipeline  # pylint: disable=import-error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Transcribe audio on GPU")
+    parser.add_argument("input", help="Path to a WAV audio file")
+    parser.add_argument(
+        "output",
+        default="transcript.txt",
+        nargs="?",
+        help="Path for the generated transcript (default: transcript.txt)",
+    )
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    args = parser.parse_args()
+
+    run_pipeline(args.input, args.output, device="cuda")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/cli.py
+++ b/src/cli.py
@@ -16,7 +16,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 def run_pipeline(
-    input_audio: str | Path, output_text: str | Path, chunk_length: int = 30
+    input_audio: str | Path,
+    output_text: str | Path,
+    chunk_length: int = 30,
+    device: str = "cpu",
 ) -> None:
     """Run the audio transcription pipeline and save results.
 
@@ -28,6 +31,8 @@ def run_pipeline(
         Destination path to write the transcribed text.
     chunk_length:
         Length of each audio chunk in seconds. Defaults to 30.
+    device:
+        Device to run the transcription model on (e.g. ``"cpu"`` or ``"cuda"``).
     """
 
     input_audio = Path(input_audio)
@@ -42,7 +47,7 @@ def run_pipeline(
     LOGGER.info("Starting transcription of %d chunks", total)
     for idx, chunk in enumerate(sorted(chunks), start=1):
         LOGGER.info("Transcribing chunk %d/%d", idx, total)
-        transcripts.append(transcribe_chunk(chunk))
+        transcripts.append(transcribe_chunk(chunk, device=device))
         try:
             chunk.unlink()
         except FileNotFoundError:
@@ -70,6 +75,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=30,
         help="Length of audio chunks in seconds (default: 30)",
     )
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="Device for local transcription model (default: cpu)",
+    )
     return parser
 
 
@@ -80,7 +91,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    run_pipeline(args.input, args.output, args.chunk_length)
+    run_pipeline(args.input, args.output, args.chunk_length, args.device)
     return 0
 
 

--- a/src/transcription/pipeline.py
+++ b/src/transcription/pipeline.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Iterable, List
 from transcription.whisper_transcriber import transcribe_file
 
-def transcribe_chunk(path: Path) -> str:
+
+def transcribe_chunk(path: Path, device: str = "cpu") -> str:
     """Transcribe a single audio chunk using the Whisper model.
 
     Args:
@@ -17,10 +18,10 @@ def transcribe_chunk(path: Path) -> str:
     speech-to-text engine. For now, it simply returns an empty string.
     """
 
-    return transcribe_file(path)
+    return transcribe_file(path, device=device)
 
 
-def transcribe_chunks(chunks_dir: str | Path) -> List[str]:
+def transcribe_chunks(chunks_dir: str | Path, device: str = "cpu") -> List[str]:
     """Sequentially transcribe audio chunks located in ``chunks_dir``.
 
     Each chunk is processed one at a time to limit memory usage. After a chunk
@@ -43,7 +44,7 @@ def transcribe_chunks(chunks_dir: str | Path) -> List[str]:
 
     try:
         for chunk in sorted(chunks_path.glob("chunk_*.wav")):
-            transcripts.append(transcribe_chunk(chunk))
+            transcripts.append(transcribe_chunk(chunk, device=device))
             try:
                 chunk.unlink()
             except FileNotFoundError:

--- a/src/transcription/whisper_transcriber.py
+++ b/src/transcription/whisper_transcriber.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Optional
 
 
-def transcribe_file(path: str | Path, model: str = "whisper-1", api_key: Optional[str] = None) -> str:
+def transcribe_file(
+    path: str | Path,
+    model: str = "whisper-1",
+    api_key: Optional[str] = None,
+    device: str = "cpu",
+) -> str:
     """Transcribe an audio file using Whisper.
 
     The function first attempts to use the OpenAI Whisper API. If an API key is
@@ -25,6 +30,9 @@ def transcribe_file(path: str | Path, model: str = "whisper-1", api_key: Optiona
     api_key:
         Optional explicit OpenAI API key. If ``None``, the ``OPENAI_API_KEY``
         environment variable is consulted.
+    device:
+        Device to run the local model on, e.g. ``"cpu"`` or ``"cuda"``.
+        Ignored when using the OpenAI API.
 
     Returns
     -------
@@ -61,6 +69,6 @@ def transcribe_file(path: str | Path, model: str = "whisper-1", api_key: Optiona
         ) from exc
 
     local_model = model if model != "whisper-1" else "base"
-    whisper_model = whisper.load_model(local_model)
+    whisper_model = whisper.load_model(local_model, device=device)
     result = whisper_model.transcribe(str(audio_path))
     return result.get("text", "")


### PR DESCRIPTION
## Summary
- allow choosing CPU or CUDA device via CLI and pipeline
- propagate device to local whisper model loading
- provide an example script for GPU-based transcription

## Testing
- `python -m pytest`
- `python src/cli.py --help`
- `python examples/transcribe_gpu.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b6f57e40948320ac8ae272e9f3453a