### PR TITLE
Remove OpenAI API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimal example project for experimenting with audio transcription.
 - **Python packages**:
 
   ```bash
-  pip install openai openai-whisper torch
+  pip install openai-whisper torch
   ```
 
   Install a CUDA-enabled build of `torch` if you plan to use a GPU.
@@ -57,7 +57,7 @@ pipeline with `device="cuda"` for convenience.
 - **Python 패키지**:
 
   ```bash
-  pip install openai openai-whisper torch
+  pip install openai-whisper torch
   ```
 
   GPU를 사용하려면 CUDA가 활성화된 `torch` 버전을 설치하세요.

--- a/src/transcription/whisper_transcriber.py
+++ b/src/transcription/whisper_transcriber.py
@@ -1,38 +1,25 @@
-"""Interface to transcribe audio using OpenAI's Whisper models."""
+"""Interface to transcribe audio using local Whisper models."""
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
-from typing import Optional
 
 
 def transcribe_file(
     path: str | Path,
-    model: str = "whisper-1",
-    api_key: Optional[str] = None,
+    model: str = "base",
     device: str = "cpu",
 ) -> str:
-    """Transcribe an audio file using Whisper.
-
-    The function first attempts to use the OpenAI Whisper API. If an API key is
-    not available or the request fails, it falls back to the local
-    ``whisper`` package (if installed).
+    """Transcribe an audio file using a local Whisper model.
 
     Parameters
     ----------
     path:
         Path to the audio file.
     model:
-        Whisper model name. For the OpenAI API the default is ``"whisper-1"``.
-        For the local fallback this translates to ``"base"`` unless another
-        model name is provided.
-    api_key:
-        Optional explicit OpenAI API key. If ``None``, the ``OPENAI_API_KEY``
-        environment variable is consulted.
+        Whisper model name, e.g. ``"base"``.
     device:
-        Device to run the local model on, e.g. ``"cpu"`` or ``"cuda"``.
-        Ignored when using the OpenAI API.
+        Device to run the model on, e.g. ``"cpu"`` or ``"cuda"``.
 
     Returns
     -------
@@ -44,31 +31,13 @@ def transcribe_file(
     if not audio_path.exists():
         raise FileNotFoundError(f"Audio file not found: {audio_path}")
 
-    # Try OpenAI API first
-    try:
-        import openai
-
-        key = api_key or os.getenv("OPENAI_API_KEY")
-        if key:
-            openai.api_key = key
-            with audio_path.open("rb") as handle:
-                response = openai.Audio.transcribe(model=model, file=handle)
-            text = response.get("text")
-            if text is not None:
-                return text
-    except Exception:
-        pass
-
-    # Fallback to local whisper package
     try:
         import whisper
     except Exception as exc:
         raise RuntimeError(
-            "Unable to transcribe audio: neither OpenAI API nor local whisper "
-            "model is available"
+            "Unable to transcribe audio: the 'whisper' package is not available"
         ) from exc
 
-    local_model = model if model != "whisper-1" else "base"
-    whisper_model = whisper.load_model(local_model, device=device)
+    whisper_model = whisper.load_model(model, device=device)
     result = whisper_model.transcribe(str(audio_path))
     return result.get("text", "")


### PR DESCRIPTION
## Summary
- simplify transcription to rely solely on the local `whisper` package
- update documentation to reflect removal of OpenAI API dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b999b62e40832092bdb034cd2e759c