### PR TITLE
feat: add model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ python src/cli.py input.wav output.txt --device cuda
 The repository also includes `examples/transcribe_gpu.py`, which invokes the
 pipeline with `device="cuda"` for convenience.
 
+## Choosing a model
+
+The pipeline uses the `base` Whisper model by default. To use a different
+model, provide the `--model` flag:
+
+```bash
+python src/cli.py input.wav output.txt --model medium
+```
+
 ## 한국어 안내
 
 ### 요구 사항
@@ -87,3 +96,12 @@ python src/cli.py input.wav output.txt --device cuda
 ```
 
 또한 저장소에는 편의를 위해 `device="cuda"`로 파이프라인을 호출하는 `examples/transcribe_gpu.py`도 포함되어 있습니다.
+
+### 모델 선택하기
+
+기본적으로 파이프라인은 `base` Whisper 모델을 사용합니다. 다른 크기의
+모델을 사용하려면 `--model` 플래그를 지정하세요:
+
+```bash
+python src/cli.py input.wav output.txt --model medium
+```

--- a/src/cli.py
+++ b/src/cli.py
@@ -20,6 +20,7 @@ def run_pipeline(
     output_text: str | Path,
     chunk_length: int = 30,
     device: str = "cpu",
+    model: str = "base",
 ) -> None:
     """Run the audio transcription pipeline and save results.
 
@@ -33,6 +34,8 @@ def run_pipeline(
         Length of each audio chunk in seconds. Defaults to 30.
     device:
         Device to run the transcription model on (e.g. ``"cpu"`` or ``"cuda"``).
+    model:
+        Whisper model name to use for transcription.
     """
 
     input_audio = Path(input_audio)
@@ -47,7 +50,7 @@ def run_pipeline(
     LOGGER.info("Starting transcription of %d chunks", total)
     for idx, chunk in enumerate(sorted(chunks), start=1):
         LOGGER.info("Transcribing chunk %d/%d", idx, total)
-        transcripts.append(transcribe_chunk(chunk, device=device))
+        transcripts.append(transcribe_chunk(chunk, device=device, model=model))
         try:
             chunk.unlink()
         except FileNotFoundError:
@@ -81,6 +84,11 @@ def build_parser() -> argparse.ArgumentParser:
         default="cpu",
         help="Device for local transcription model (default: cpu)",
     )
+    parser.add_argument(
+        "--model",
+        default="base",
+        help="Whisper model size to use (default: base)",
+    )
     return parser
 
 
@@ -91,7 +99,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    run_pipeline(args.input, args.output, args.chunk_length, args.device)
+    run_pipeline(args.input, args.output, args.chunk_length, args.device, args.model)
     return 0
 
 

--- a/src/transcription/pipeline.py
+++ b/src/transcription/pipeline.py
@@ -8,7 +8,7 @@ from typing import Iterable, List
 from transcription.whisper_transcriber import transcribe_file
 
 
-def transcribe_chunk(path: Path, device: str = "cpu") -> str:
+def transcribe_chunk(path: Path, device: str = "cpu", model: str = "base") -> str:
     """Transcribe a single audio chunk using the Whisper model.
 
     Args:
@@ -18,10 +18,12 @@ def transcribe_chunk(path: Path, device: str = "cpu") -> str:
     speech-to-text engine. For now, it simply returns an empty string.
     """
 
-    return transcribe_file(path, device=device)
+    return transcribe_file(path, model=model, device=device)
 
 
-def transcribe_chunks(chunks_dir: str | Path, device: str = "cpu") -> List[str]:
+def transcribe_chunks(
+    chunks_dir: str | Path, device: str = "cpu", model: str = "base"
+) -> List[str]:
     """Sequentially transcribe audio chunks located in ``chunks_dir``.
 
     Each chunk is processed one at a time to limit memory usage. After a chunk
@@ -44,7 +46,7 @@ def transcribe_chunks(chunks_dir: str | Path, device: str = "cpu") -> List[str]:
 
     try:
         for chunk in sorted(chunks_path.glob("chunk_*.wav")):
-            transcripts.append(transcribe_chunk(chunk, device=device))
+            transcripts.append(transcribe_chunk(chunk, device=device, model=model))
             try:
                 chunk.unlink()
             except FileNotFoundError:


### PR DESCRIPTION
## Summary
- allow specifying Whisper model for chunk transcription
- expose `--model` option in CLI to choose model size
- document model selection in README (English and Korean)

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b99fdbd1f88320958c75971b379771