### PR TITLE
feat: expose whisper decoding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ model, provide the `--model` flag:
 python src/cli.py input.wav output.txt --model medium
 ```
 
+## Tuning transcription parameters
+
+The CLI exposes a few Whisper decoding options. The most common are
+`--temperature` (default: `0.0`) and `--beam-size` (default: `5`). For example:
+
+```bash
+python src/cli.py input.wav output.txt --temperature 0.7 --beam-size 3
+```
+
+Higher temperatures make outputs more random, while larger beam sizes explore
+more decoding paths.
+
 ## 한국어 안내
 
 ### 요구 사항
@@ -105,3 +117,14 @@ python src/cli.py input.wav output.txt --device cuda
 ```bash
 python src/cli.py input.wav output.txt --model medium
 ```
+
+### 디코딩 파라미터 조정하기
+
+CLI는 Whisper 디코더의 몇 가지 옵션을 제공합니다. 대표적으로
+`--temperature`(기본값: `0.0`)와 `--beam-size`(기본값: `5`)가 있습니다:
+
+```bash
+python src/cli.py input.wav output.txt --temperature 0.7 --beam-size 3
+```
+
+높은 temperature는 결과의 무작위성을 높이고, 큰 beam size는 더 많은 탐색 경로를 고려합니다.

--- a/src/transcription/pipeline.py
+++ b/src/transcription/pipeline.py
@@ -8,21 +8,23 @@ from typing import Iterable, List
 from transcription.whisper_transcriber import transcribe_file
 
 
-def transcribe_chunk(path: Path, device: str = "cpu", model: str = "base") -> str:
+def transcribe_chunk(
+    path: Path, device: str = "cpu", model: str = "base", **kwargs
+) -> str:
     """Transcribe a single audio chunk using the Whisper model.
 
     Args:
         path (Path): Path to the audio file to transcribe.
-
-    Replace the body of this function with calls to your actual
-    speech-to-text engine. For now, it simply returns an empty string.
+        device (str): Target device for the model.
+        model (str): Whisper model name.
+        **kwargs: Additional keyword arguments for ``transcribe_file``.
     """
 
-    return transcribe_file(path, model=model, device=device)
+    return transcribe_file(path, model=model, device=device, **kwargs)
 
 
 def transcribe_chunks(
-    chunks_dir: str | Path, device: str = "cpu", model: str = "base"
+    chunks_dir: str | Path, device: str = "cpu", model: str = "base", **kwargs
 ) -> List[str]:
     """Sequentially transcribe audio chunks located in ``chunks_dir``.
 
@@ -46,7 +48,9 @@ def transcribe_chunks(
 
     try:
         for chunk in sorted(chunks_path.glob("chunk_*.wav")):
-            transcripts.append(transcribe_chunk(chunk, device=device, model=model))
+            transcripts.append(
+                transcribe_chunk(chunk, device=device, model=model, **kwargs)
+            )
             try:
                 chunk.unlink()
             except FileNotFoundError:

--- a/src/transcription/whisper_transcriber.py
+++ b/src/transcription/whisper_transcriber.py
@@ -9,6 +9,7 @@ def transcribe_file(
     path: str | Path,
     model: str = "base",
     device: str = "cpu",
+    **kwargs,
 ) -> str:
     """Transcribe an audio file using a local Whisper model.
 
@@ -20,6 +21,8 @@ def transcribe_file(
         Whisper model name, e.g. ``"base"``.
     device:
         Device to run the model on, e.g. ``"cpu"`` or ``"cuda"``.
+    **kwargs:
+        Additional keyword arguments passed to ``whisper_model.transcribe``.
 
     Returns
     -------
@@ -39,5 +42,5 @@ def transcribe_file(
         ) from exc
 
     whisper_model = whisper.load_model(model, device=device)
-    result = whisper_model.transcribe(str(audio_path))
+    result = whisper_model.transcribe(str(audio_path), **kwargs)
     return result.get("text", "")


### PR DESCRIPTION
## Summary
- forward arbitrary kwargs in whisper transcription
- allow temperature and beam-size parameters in pipeline and CLI
- document default decoding settings and usage

## Testing
- `python -m py_compile src/transcription/whisper_transcriber.py src/transcription/pipeline.py src/cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9a21bdcb883208fecf2a3e424bb6d