### PR TITLE
Add optional Korean post-correction and custom dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ A minimal example project for experimenting with audio transcription.
 - **Python packages**:
 
   ```bash
-  pip install openai-whisper torch pydub webrtcvad noisereduce
+  pip install openai-whisper torch pydub webrtcvad noisereduce language_tool_python
+
+  # Optional Korean text correction helpers
+  pip install git+https://github.com/ssut/py-hanspell.git
+  pip install git+https://github.com/haven-jeon/KoSpacing.git
   ```
 
   Install a CUDA-enabled build of `torch` if you plan to use a GPU.
@@ -82,6 +86,22 @@ with `--skip-preprocessing`:
 python src/cli.py input.wav output.txt --skip-preprocessing
 ```
 
+## Text correction
+
+The `korean_corrector` module fixes common spelling mistakes using
+`language_tool_python`. For additional cleanup you can chain optional
+correctors like [py-hanspell](https://github.com/ssut/py-hanspell) or
+[KoSpacing](https://github.com/haven-jeon/KoSpacing) and preserve
+domain‑specific terms via a custom dictionary:
+
+```python
+from src.text_correction.korean_corrector import correct_text
+
+domain_words = ["오픈AI", "GPT-4o"]
+text = correct_text("오픈 ai는 환영합니디", secondary="hanspell", user_dict=domain_words)
+print(text)
+```
+
 ## 한국어 안내
 
 ### 요구 사항
@@ -91,7 +111,11 @@ python src/cli.py input.wav output.txt --skip-preprocessing
 - **Python 패키지**:
 
   ```bash
-  pip install openai-whisper torch pydub webrtcvad noisereduce
+  pip install openai-whisper torch pydub webrtcvad noisereduce language_tool_python
+
+  # 선택적 한국어 텍스트 교정 도구
+  pip install git+https://github.com/ssut/py-hanspell.git
+  pip install git+https://github.com/haven-jeon/KoSpacing.git
   ```
 
   GPU를 사용하려면 CUDA가 활성화된 `torch` 버전을 설치하세요.
@@ -153,4 +177,19 @@ python src/cli.py input.wav output.txt --temperature 0.7 --beam-size 3
 
 ```bash
 python src/cli.py input.wav output.txt --skip-preprocessing
+```
+
+### 텍스트 교정
+
+`korean_corrector` 모듈은 `language_tool_python`으로 기본적인 맞춤법을 수정합니다.
+추가 후처리가 필요하다면 [py-hanspell](https://github.com/ssut/py-hanspell)이나
+[KoSpacing](https://github.com/haven-jeon/KoSpacing)과 같은 보조 교정기를 연결하고,
+사용자 정의 단어 사전으로 도메인 특화 용어를 보호할 수 있습니다:
+
+```python
+from src.text_correction.korean_corrector import correct_text
+
+domain_words = ["오픈AI", "GPT-4o"]
+text = correct_text("오픈 ai는 환영합니디", secondary="hanspell", user_dict=domain_words)
+print(text)
 ```

--- a/src/text_correction/korean_corrector.py
+++ b/src/text_correction/korean_corrector.py
@@ -2,37 +2,106 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Dict, Iterable, List, Tuple
 
 
-def correct_text(raw_text: str) -> str:
+def _mask_user_words(text: str, words: Iterable[str]) -> Tuple[str, Dict[str, str]]:
+    """Replace ``words`` in ``text`` with placeholders.
+
+    The placeholders allow the spell checker to run without altering
+    domain-specific terms supplied by the user.
+    """
+
+    placeholders: Dict[str, str] = {}
+    for i, word in enumerate(words):
+        placeholder = f"__USERWORD_{i}__"
+        placeholders[placeholder] = word
+        text = text.replace(word, placeholder)
+    return text, placeholders
+
+
+def _unmask_user_words(text: str, placeholders: Dict[str, str]) -> str:
+    """Restore placeholders inserted by :func:`_mask_user_words`."""
+
+    for placeholder, word in placeholders.items():
+        text = text.replace(placeholder, word)
+    return text
+
+
+def correct_text(
+    raw_text: str,
+    secondary: str | None = None,
+    user_dict: Iterable[str] | None = None,
+) -> str:
     """Return a grammatically corrected version of ``raw_text``.
 
-    The function attempts to use ``language_tool_python`` to fix common
-    spacing and spelling mistakes in Korean text. If the library is not
-    available or an error occurs during correction, the original text is
-    returned unchanged.
+    Parameters
+    ----------
+    raw_text:
+        Text to correct.
+    secondary:
+        Name of an optional secondary corrector (``"hanspell"`` or
+        ``"kospacing"``).
+    user_dict:
+        Iterable of words that should be preserved during correction.
+
+    The function attempts to use ``language_tool_python`` to fix common spacing
+    and spelling mistakes in Korean text. Optional secondary correctors are
+    applied afterwards. If any library is unavailable or an error occurs during
+    correction, the original text is returned unchanged.
     """
+
+    text = raw_text
+    placeholders: Dict[str, str] = {}
+
+    if user_dict:
+        text, placeholders = _mask_user_words(text, user_dict)
 
     try:
         import language_tool_python
-    except Exception:
-        return raw_text
 
-    try:
         tool = language_tool_python.LanguageTool("ko-KR")
-        return tool.correct(raw_text)
+        corrected = tool.correct(text)
     except Exception:
-        return raw_text
+        corrected = text
+
+    if secondary == "hanspell":
+        try:
+            from hanspell import spell_checker
+
+            corrected = spell_checker.check(corrected).checked
+        except Exception:
+            pass
+    elif secondary == "kospacing":
+        try:
+            from kospacing import KoSpacing
+
+            spacing = KoSpacing()
+            corrected = spacing(corrected)
+        except Exception:
+            pass
+
+    if placeholders:
+        corrected = _unmask_user_words(corrected, placeholders)
+
+    return corrected
 
 
-def correct_chunks(chunks: Iterable[str]) -> str:
+def correct_chunks(
+    chunks: Iterable[str],
+    secondary: str | None = None,
+    user_dict: Iterable[str] | None = None,
+) -> str:
     """Correct multiple chunks and join them into a single string.
 
     Parameters
     ----------
     chunks:
         Iterable of raw transcription strings.
+    secondary:
+        Optional secondary corrector passed to :func:`correct_text`.
+    user_dict:
+        Words that should remain unchanged during correction.
 
     Returns
     -------
@@ -43,5 +112,7 @@ def correct_chunks(chunks: Iterable[str]) -> str:
     corrected: List[str] = []
     for chunk in chunks:
         if chunk:
-            corrected.append(correct_text(chunk))
+            corrected.append(
+                correct_text(chunk, secondary=secondary, user_dict=user_dict)
+            )
     return " ".join(corrected)


### PR DESCRIPTION
## Summary
- Add optional secondary correctors (py-hanspell/KoSpacing) and user dictionary masking to Korean text correction
- Allow chunk correction to forward secondary and user dictionary options
- Document new dependencies and usage examples for text correction in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa0f652c832092a69bf246a88e5f